### PR TITLE
b2_backend: don't raise errors when file is missing on server

### DIFF
--- a/src/s3ql/backends/b2/b2_backend.py
+++ b/src/s3ql/backends/b2/b2_backend.py
@@ -527,10 +527,8 @@ class B2Backend(AbstractBackend):
         else:
             file_ids = self._list_file_versions(key)
 
-        if not file_ids:
-            raise NoSuchObject(key)
-
-        self._delete_file_ids(file_ids, force)
+        if file_ids:
+            self._delete_file_ids(file_ids, force)
 
     @retry
     def _delete_file_ids(self, file_ids, force=False, is_retry=False):


### PR DESCRIPTION
The other backends all silently ignore missing file errors, so b2 should as well.
This makes the unit tests pass (in combination with my other PR)

Fixes bug #338